### PR TITLE
Build fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/kvj/Lima1.git
 [submodule "libraries/Lima1"]
 	path = libraries/Lima1
-	url = git@github:kvj/Lima1Common.git
+	url = https://github.com/kvj/Lima1Common.git

--- a/prepare-clean-checkout.sh
+++ b/prepare-clean-checkout.sh
@@ -4,7 +4,7 @@ cd jni
 rm -r vim
 rm -r libiconv
 wget ftp://ftp.vim.org/pub/vim/unix/vim-7.3.tar.bz2
-tar jxvf vim-7.4.tar.bz2
+tar jxvf vim-7.3.tar.bz2
 mv vim73 vim
 rm vim/src/auto/config.h
 rm vim/src/feature.h


### PR DESCRIPTION
I needed these to build vimtouch.  It looks like the original URL used an ssh config entry for github; as well as using the full address this switches to http so that it should work without a github account.

I also needed to fiddle with the gradle wrapper to make it use a newer version to get rid of a failure that's associated with plugins built for a later version, although I don't know why I needed to do that.  Is there a canonical gradle wrapper setup that should be added to the repository?
