### PR TITLE
allow commands with spaces in the quickbar

### DIFF
--- a/src/net/momodalo/app/vimtouch/VimTouch.java
+++ b/src/net/momodalo/app/vimtouch/VimTouch.java
@@ -671,7 +671,7 @@ public class VimTouch extends ActionBarActivity implements
             TextView textview = null;
             String caption = line;
             String keys = line;
-            int spaceIndex = line.indexOf(' ');
+            int spaceIndex = line.lastIndexOf(' ');
             if (-1 != spaceIndex) {
                 // Have caption
                 keys = line.substring(0, spaceIndex);


### PR DESCRIPTION
The quickbar currently breaks quickbar commands into a command and a caption at the first space. This makes it break it on the last space so that you can use commands with space in them (e.g. :new /mnt/sdcard/long/path/to/my/file) as long as you include a caption
